### PR TITLE
Some updates on configs for Inline entity form module tests.

### DIFF
--- a/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_reference_type.default.yml
+++ b/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_reference_type.default.yml
@@ -1,4 +1,4 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:

--- a/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_simple_single.default.yml
+++ b/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_simple_single.default.yml
@@ -1,4 +1,4 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:

--- a/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_complex.default.yml
+++ b/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_complex.default.yml
@@ -1,4 +1,4 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:

--- a/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.default.yml
+++ b/tests/modules/inline_entity_form_test/config/install/core.entity_form_display.node.ief_test_custom.default.yml
@@ -1,4 +1,4 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:

--- a/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_simple_single.default.yml
+++ b/tests/modules/inline_entity_form_test/config/install/core.entity_view_display.node.ief_simple_single.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.ief_simple_single.single
+    - node.type.ief_simple_single
+  module:
+    - user
+id: node.ief_simple_single.default
+targetEntityType: node
+bundle: ief_simple_single
+mode: default
+content:
+  single:
+    type: entity_reference_label
+    weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+hidden:
+  links: true
+

--- a/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_simple_single.single.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_simple_single.single.yml
@@ -4,9 +4,9 @@ dependencies:
   config:
     - field.storage.node.single
     - node.type.ief_simple_single
+    - node.type.ief_test_custom
   module:
     - inline_entity_form_test
-    - entity_reference
   enforced:
     module:
       - inline_entity_form_test

--- a/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.all_bundles.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.all_bundles.yml
@@ -1,4 +1,4 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:
@@ -6,7 +6,6 @@ dependencies:
     - node.type.ief_test_complex
   module:
     - inline_entity_form_test
-    - entity_reference
   enforced:
     module:
       - inline_entity_form_test

--- a/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.multi.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.field.node.ief_test_complex.multi.yml
@@ -1,12 +1,12 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.multi
-    - node.type.ief_test_complex
+    - node.type.ief_reference_type
+    - node.type.ief_test_custom
   module:
     - inline_entity_form_test
-    - entity_reference
   enforced:
     module:
       - inline_entity_form_test
@@ -21,7 +21,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: default:node
+  handler: 'default:node'
   handler_settings:
     target_bundles:
       ief_reference_type: ief_reference_type

--- a/tests/modules/inline_entity_form_test/config/install/field.storage.node.all_bundles.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.storage.node.all_bundles.yml
@@ -1,9 +1,8 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   module:
     - inline_entity_form_test
-    - entity_reference
     - node
   enforced:
     module:
@@ -14,7 +13,7 @@ entity_type: node
 type: entity_reference
 settings:
   target_type: node
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: false

--- a/tests/modules/inline_entity_form_test/config/install/field.storage.node.multi.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.storage.node.multi.yml
@@ -1,9 +1,8 @@
-langcode: und
+langcode: en
 status: true
 dependencies:
   module:
     - inline_entity_form_test
-    - entity_reference
     - node
   enforced:
     module:
@@ -14,7 +13,7 @@ entity_type: node
 type: entity_reference
 settings:
   target_type: node
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: false

--- a/tests/modules/inline_entity_form_test/config/install/field.storage.node.single.yml
+++ b/tests/modules/inline_entity_form_test/config/install/field.storage.node.single.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   module:
     - inline_entity_form_test
-    - entity_reference
     - node
   enforced:
     module:
@@ -14,7 +13,7 @@ entity_type: node
 type: entity_reference
 settings:
   target_type: node
-module: entity_reference
+module: core
 locked: false
 cardinality: 1
 translatable: false

--- a/tests/modules/inline_entity_form_test/config/install/node.type.ief_reference_type.yml
+++ b/tests/modules/inline_entity_form_test/config/install/node.type.ief_reference_type.yml
@@ -6,4 +6,4 @@ new_revision: false
 preview_mode: 1
 display_submitted: false
 status: true
-langcode: und
+langcode: en

--- a/tests/modules/inline_entity_form_test/config/install/node.type.ief_simple_single.yml
+++ b/tests/modules/inline_entity_form_test/config/install/node.type.ief_simple_single.yml
@@ -6,4 +6,4 @@ new_revision: false
 preview_mode: 1
 display_submitted: false
 status: true
-langcode: und
+langcode: en

--- a/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_complex.yml
+++ b/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_complex.yml
@@ -6,4 +6,4 @@ new_revision: false
 preview_mode: 1
 display_submitted: false
 status: true
-langcode: und
+langcode: en

--- a/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_custom.yml
+++ b/tests/modules/inline_entity_form_test/config/install/node.type.ief_test_custom.yml
@@ -6,4 +6,4 @@ new_revision: false
 preview_mode: 1
 display_submitted: false
 status: true
-langcode: und
+langcode: en

--- a/tests/modules/inline_entity_form_test/inline_entity_form_test.info.yml
+++ b/tests/modules/inline_entity_form_test/inline_entity_form_test.info.yml
@@ -5,7 +5,6 @@ core: 8.x
 package: Testing
 version: VERSION
 dependencies:
-  - entity_reference
   - inline_entity_form
   - node
   - file


### PR DESCRIPTION
- remove entity_reference dependency
- use en as language
- add display config for ief_simple_single, we need the reference label for test results.